### PR TITLE
Add "get_first_professor_by_school_and_name"

### DIFF
--- a/ratemyprofessor/__init__.py
+++ b/ratemyprofessor/__init__.py
@@ -94,7 +94,7 @@ def get_first_professor_by_school_and_name(college: School, professor_name: str)
     This returns the first professor listed on Rate My Professor, regardless of rating.
     For instance, searching "Smith" using the School of Case Western Reserve University will return 5 results,
     but only the top result will be returned.
-    This method is faster than `get_professor_by_school_and_name`, but may provide worse/better results depending on your usecase.
+    This method is faster than `get_professor_by_school_and_name`, but may provide worse/better results depending on your use case.
 
     :param college: The professor's school.
     :param professor_name: The professor's name.

--- a/ratemyprofessor/__init__.py
+++ b/ratemyprofessor/__init__.py
@@ -86,6 +86,32 @@ def get_professor_by_school_and_name(college: School, professor_name: str):
 
     return max_professor
 
+def get_first_professor_by_school_and_name(college: School, professor_name: str):
+    """
+    Gets a Professor with the specified School and professor name.
+
+    This only returns 1 professor, so make sure that the name is specific.
+    This returns the first professor listed on Rate My Professor, regardless of rating.
+    For instance, searching "Smith" using the School of Case Western Reserve University will return 5 results,
+    but only the top result will be returned.
+    This method is faster than `get_professor_by_school_and_name`, but may provide worse/better results depending on your usecase.
+
+    :param college: The professor's school.
+    :param professor_name: The professor's name.
+    :return: The professor that matches the school and name. If no professors are found, this will return None.
+    """
+    url = 'https://www.ratemyprofessors.com/search/professors/%s?q=%s' % (college.id, professor_name)
+    page = requests.get(url)
+    data = re.findall(r'"legacyId":(\d+)', page.text)
+
+    for professor_data in data:
+        try:
+            return Professor(int(professor_data))
+        except ValueError:
+            pass
+
+    return None
+
 
 def get_professors_by_school_and_name(college: School, professor_name: str):
     """


### PR DESCRIPTION
`get_first_professor_by_school_and_name` functions like `get_professor_by_school_and_name`, except it does not check the professors' number of ratings. Instead, it returns the first professor in its search results that a `Professor` object can be created for.

As it doesn't require rating data, it doesn't need to create a `Professor` object for every single professor in its search results, therefore increasing performance by making less requests to RMP :DDD

Also, it is useful for when the developer wants to trust RMP's search algorithm, and may not strictly only want the professor with the most ratings.

It duplicates a lot of `get_professors_by_school_and_name`'s code, which slightly sucks, but I also am not sure how else to do things without also sacrificing code readability or losing the performance benefits.